### PR TITLE
fix: 🪲 unnecessary message when a module is already installed.

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,11 @@
 import launch
 
-for dep in ['onnx', 'onnxruntime', 'opencv-python', 'numpy', 'Pillow']:
+for dep in ['onnx', 'onnxruntime', 'numpy']:
     if not launch.is_installed(dep):
         launch.run_pip(f"install {dep}", f"{dep} for ABG_extension")
+
+if not launch.is_installed("cv2"):
+    launch.run_pip("install opencv-python", "opencv-python")
+
+if not launch.is_installed("PIL"):
+    launch.run_pip("install Pillow", "Pillow")


### PR DESCRIPTION
As https://github.com/KutsuyaYuki/ABG_extension/issues/6#issuecomment-1497758365 mentioned.
when using the `importlib.util.find_spec` method, the module name should be a parameter instead of the package name.